### PR TITLE
Change format of tests

### DIFF
--- a/README_SYNTAX.md
+++ b/README_SYNTAX.md
@@ -278,44 +278,47 @@ define(["intern!object",
         "utils/Steps"],  
         function (registerSuite, expect, require, TestUtils, Steps) {
 
-    var browser,
-        selector = {
-            ADMIN_CONSOLE_MENU: "div.tools-link ul",
-            ADMIN_CONSOLE_MENU_ITEM: "div.tools-link ul li"
+    var selector = {
+        ADMIN_CONSOLE_MENU: "div.tools-link ul",
+        ADMIN_CONSOLE_MENU_ITEM: "div.tools-link ul li"
+    };
+
+    registerSuite(function() {
+        var browser;
+        
+        return {
+            name: "Admin console test",
+    
+            setup: function() {
+                browser = this.remote;
+                browser = Steps.loginAs(browser, "admin");
+                browser = Steps.gotoAdminConsole(browser);
+                return browser;
+            },
+    
+            teardown: function() {
+                return Steps.logout(browser);
+            },
+    
+            beforeEach: function() {
+                browser.end();
+            },
+    
+            "Test admin console menus": function() {
+                return browser
+    
+                .findAllByCssSelector(selector.ADMIN_CONSOLE_MENU)
+                    .then(function (menus) {
+                        expect(menus).to.have.length.of(3, "An incorrect number of admin menus is seen");
+                    })
+                    .end()
+    
+                .findAllByCssSelector(selector.ADMIN_CONSOLE_MENU_ITEM)
+                    .then(function (menuItems) {
+                        expect(menuItems).to.have.length.of(9, "An incorrect number of admin menu items is seen");
+                    });
+            }
         };
-
-    registerSuite({
-        name: "Admin console test",
-
-        setup: function() {
-            browser = this.remote;
-            browser = Steps.loginAs(browser, "admin");
-            browser = Steps.gotoAdminConsole(browser);
-            return browser;
-        },
-
-        teardown: function() {
-            return Steps.logout(browser);
-        },
-
-        beforeEach: function() {
-            browser.end();
-        },
-
-        "Test admin console menus": function() {
-            return browser
-
-            .findAllByCssSelector(selector.ADMIN_CONSOLE_MENU)
-                .then(function (menus) {
-                    expect(menus).to.have.length.of(3, "An incorrect number of admin menus is seen");
-                })
-                .end()
-
-            .findAllByCssSelector(selector.ADMIN_CONSOLE_MENU_ITEM)
-                .then(function (menuItems) {
-                    expect(menuItems).to.have.length.of(9, "An incorrect number of admin menu items is seen");
-                });
-        }
     });
 });
 ```


### PR DESCRIPTION
As part of the work into running tests concurrently, I came across problems that I eventually found a solution for, and it's that environments share variables at the top level of the test. The suggested changes are what I've done in Aikau to fix the problem (lots of search-and-replace, lots of manual updating!!), and functionally have no effect at all on the tests apart from making them safe for running concurrently on a single machine (e.g. vagrant, local). If you only ever intend to do BrowserStack multiple environments, then the fact that they're all spun up on separate VMs may negate this requirement, but I believe this relatively small change is well worth doing in terms of test robustness.

P.S. There's lots of whitespace changes showing up. To ignore them, put this on the end of the URL on the comparison/diff page: `?w=1`
